### PR TITLE
workflow for checking abox conventions

### DIFF
--- a/.github/workflow_resources/abox_quality_shacl.ttl
+++ b/.github/workflow_resources/abox_quality_shacl.ttl
@@ -1,0 +1,70 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix pmdco: <https://w3id.org/pmd/co/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix ex: <http://www.example.org/#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+ex:TermEditorPropertyShape a sh:PropertyShape ;
+    sh:path obo:IAO_0000117 ;
+    sh:pattern "^PERSON:(.*)" ;
+    sh:message "must have at least one term editor (obo:IAO_0000117). The object must be a xsd:string which matches the pattern \"^PERSON:(.*)\""@en ;
+	sh:minCount 1 .
+
+ex:CurationStatusPropertyShape a sh:PropertyShape ;
+    sh:path obo:IAO_0000114 ;
+    sh:class obo:IAO_0000078;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:message "must have exactly one curation status (obo:IAO_0000114). Values must be of class obo:IAO_0000078"@en .
+
+ex:EnglishRdfsLabelPropertyShape a sh:PropertyShape ;
+    sh:path rdfs:label ;
+    sh:qualifiedValueShape [
+      	sh:datatype rdf:langString ;
+        sh:languageIn ( "en" ) ;
+    ] ;
+    sh:qualifiedMinCount 1 ;
+    sh:message "must have at least one rdfs:label with language \"en\""@en .
+
+ex:ClassRdfsLabelPropertyShape a sh:PropertyShape ;
+	sh:path rdfs:label ;
+	sh:pattern "^(([A-Z][a-z]+)( |$))+" ;
+    sh:message "must be like \"Entitled String Style\" (Pattern: \"^(([A-Z][a-z]+)( |$))+\")" .
+
+ex:PropertyRdfsLabelPropertyShape a sh:PropertyShape ;
+	sh:path rdfs:label ;
+	sh:pattern "^(([a-z]+)( |$))+" ;
+    sh:message "must be like \"natural language string style\" (Pattern: \"^(([a-z]+)( |$))+\")" .
+
+ex:EnglishSkosDefinitionPropertyShape a sh:PropertyShape ;
+    sh:path skos:definition ;
+    sh:qualifiedValueShape [
+      	sh:datatype rdf:langString ;
+        sh:languageIn ( "en" ) ;
+    ] ;
+    sh:qualifiedMinCount 1 ;
+    sh:message "must have at least one skos:definition with language \"en\""@en .
+
+ex:ClassConvention a rdfs:Class, sh:NodeShape ;
+	sh:targetClass owl:Class ;
+	sh:property ex:TermEditorPropertyShape ,
+				ex:CurationStatusPropertyShape ,
+				ex:EnglishRdfsLabelPropertyShape ,
+				ex:EnglishSkosDefinitionPropertyShape ,
+				ex:ClassRdfsLabelPropertyShape ;
+	.
+
+ex:PropertyConvention a rdfs:Class, sh:NodeShape ;
+	sh:targetClass owl:AnnotationProperty , owl:ObjectProperty ;
+	sh:property ex:TermEditorPropertyShape ,
+				ex:CurationStatusPropertyShape ,
+				ex:EnglishRdfsLabelPropertyShape ,
+				ex:EnglishSkosDefinitionPropertyShape ,
+				ex:PropertyRdfsLabelPropertyShape ;
+	.

--- a/.github/workflow_resources/q_countValidationResults.sparql
+++ b/.github/workflow_resources/q_countValidationResults.sparql
@@ -1,0 +1,9 @@
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+SELECT ?resultSeverity (count(?resultSeverity) as ?count)
+WHERE {
+    ?vr a sh:ValidationResult .
+    ?vr sh:focusNode ?focusNode .
+    ?vr sh:resultSeverity ?resultSeverity .
+    FILTER(STRSTARTS(STR(?focusNode), "https://w3id.org/pmd/co/"))
+} GROUP BY ?resultSeverity

--- a/.github/workflow_resources/q_listValidationResults.sparql
+++ b/.github/workflow_resources/q_listValidationResults.sparql
@@ -1,0 +1,10 @@
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+SELECT ?focusNode ?resultMessage ?resultSeverity
+WHERE {
+    ?vr a sh:ValidationResult .
+    ?vr sh:focusNode ?focusNode .
+    ?vr sh:resultMessage ?resultMessage .
+    ?vr sh:resultSeverity ?resultSeverity .
+    FILTER(STRSTARTS(STR(?focusNode), "https://w3id.org/pmd/co/"))
+}

--- a/.github/workflows/abox_conventions_shacl.yaml
+++ b/.github/workflows/abox_conventions_shacl.yaml
@@ -1,0 +1,43 @@
+name: shacl validation of abox conventions
+
+on:
+  push:
+    branches:
+    - develop-3.0.*
+
+jobs:
+  aboxshacl:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        path: main
+    - name: Merge and reason
+      run: |
+           curl -L -o robot.jar "https://github.com/ontodev/robot/releases/latest/download/robot.jar"
+           java -jar robot.jar merge --input main/pmd-core.ttl --output pmd-core-merged.ttl
+           java -jar robot.jar reason --reasoner elk --input pmd-core-merged.ttl --output pmd-core-reasoned.ttl
+    - name: pyshacl
+      run: |
+           pip install pyshacl
+           trap 'E=$?; test $E -eq 1 && echo "trapped exit code 1" && exit 0 || exit $E' EXIT
+           python3 -m pyshacl -f turtle -s main/.github/workflow_resources/abox_quality_shacl.ttl pmd-core-reasoned.ttl > shacl_report.ttl
+    - name: Archive shacl_report.ttl
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: shacl_report.ttl
+        path: |
+          shacl_report.ttl
+    - name: Query shacl result
+      run: |
+           trap - EXIT
+           java -jar robot.jar query --input shacl_report.ttl --query main/.github/workflow_resources/q_listValidationResults.sparql ValidationReport.csv
+           java -jar robot.jar query --input shacl_report.ttl --query main/.github/workflow_resources/q_countValidationResults.sparql ValidationSummary.csv
+    - name: Archive Validation Reports
+      uses: actions/upload-artifact@v4
+      with:
+        name: validation_reports
+        path: |
+          ValidationReport.csv
+          ValidationSummary.csv


### PR DESCRIPTION
Hi @BerndBayerlein @MarkusSchilling @ThHanke,

wie gestern besprochen habe ich einen Vorschlag zur Überprüfung unserer in https://github.com/materialdigital/core-ontology/blob/develop-3.0.0/modules/README.md festgelegten Konventionen erarbeitet. Ich glaube man kann die Vorgehensweise sicher noch schlanker gestalten (bisher wird recht brachial alles gemerged und gereasoned und nachher werden nur die Violations ausgegeben, die Objekte im PMD-namespace betreffen), es scheint aber zu funktionieren.

Viele Grüße
Matthias