### PR TITLE
resolved issue 147-missing-vocabulary-for-medium

### DIFF
--- a/src/ontology/components/pmdco-manufacturing.owl
+++ b/src/ontology/components/pmdco-manufacturing.owl
@@ -76,6 +76,7 @@ Declaration(Class(<https://w3id.org/pmd/co/PMD_0000943>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0000975>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0000977>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0000988>))
+Declaration(Class(<https://w3id.org/pmd/co/PMD_0020113>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0020138>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0020139>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0020143>))
@@ -506,7 +507,7 @@ AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> <https://w3
 AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#example> <https://w3id.org/pmd/co/PMD_0000807> "Pouring, Embedding, Encasing"@en)
 SubClassOf(<https://w3id.org/pmd/co/PMD_0000807> <https://w3id.org/pmd/co/PMD_0000806>)
 
-# Class: <https://w3id.org/pmd/co/PMD_0000808> (joining by shaping)
+# Class: <https://w3id.org/pmd/co/PMD_0000808> (Fügen Durch Umformen)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000114> <https://w3id.org/pmd/co/PMD_0000808> <http://purl.obolibrary.org/obo/IAO_0000122>)
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000117> <https://w3id.org/pmd/co/PMD_0000808> "PMDco Team")
@@ -861,7 +862,7 @@ AnnotationAssertion(rdfs:label <https://w3id.org/pmd/co/PMD_0020139> "melt"@en)
 AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> <https://w3id.org/pmd/co/PMD_0020139> "A melt is an object (material entity) that exists in a liquid state as a result of the phase transition from solid due to thermal energy input. In materials science, it typically refers to metals, alloys, or other substances maintained above their melting point."@en)
 AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> <https://w3id.org/pmd/co/PMD_0020139> "Eine Schmelze ist ein Objekt (eine materielle Einheit), das aufgrund des Phasenübergangs von einem Festkörper durch thermische Energiezufuhr in einem flüssigen Zustand vorliegt. In der Werkstoffkunde bezieht sich der Begriff in der Regel auf Metalle, Legierungen oder andere Stoffe, die oberhalb ihres Schmelzpunkts gehalten werden."@de)
 AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#example> <https://w3id.org/pmd/co/PMD_0020139> "A pool of molten steel during casting."@en)
-SubClassOf(<https://w3id.org/pmd/co/PMD_0020139> <http://purl.obolibrary.org/obo/BFO_0000030>)
+SubClassOf(<https://w3id.org/pmd/co/PMD_0020139> <https://w3id.org/pmd/co/PMD_0020113>)
 
 # Class: <https://w3id.org/pmd/co/PMD_0020143> (process chain)
 

--- a/src/ontology/pmdco-edit.owl
+++ b/src/ontology/pmdco-edit.owl
@@ -40,11 +40,31 @@ Annotation(dcterms:description "The PMD Core Ontology (PMDco) is a comprehensive
 Annotation(dcterms:license <https://creativecommons.org/licenses/by/4.0/>)
 Annotation(dcterms:title "PMD Core Ontology")
 
+Declaration(Class(:PMD_0020113))
+Declaration(Class(:PMD_0020114))
 Declaration(AnnotationProperty(dcterms:contributor))
 Declaration(AnnotationProperty(dcterms:creator))
 Declaration(AnnotationProperty(dcterms:description))
 Declaration(AnnotationProperty(dcterms:license))
 Declaration(AnnotationProperty(dcterms:title))
+
+
+############################
+#   Classes
+############################
+
+# Class: :PMD_0020113 (fluid (object))
+
+AnnotationAssertion(rdfs:label :PMD_0020113 "fluid (object)"@en)
+AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> :PMD_0020113 "fuild (object) is an object that consists of some portion of matter which bears an aggregate state that concretizes a liquid or gaseous aggregate state."@en)
+SubClassOf(:PMD_0020113 <http://purl.obolibrary.org/obo/BFO_0000030>)
+
+# Class: :PMD_0020114 (medium role)
+
+AnnotationAssertion(rdfs:label :PMD_0020114 "medium role"@en)
+AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> :PMD_0020114 "Medium role is a role beared by an object which implies that the object serves as an intermediary for the transmission of something else, like energy, force, or information."@en)
+AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#example> :PMD_0020114 "Air in the air cooling process, N2 atmosphere in a furnace cooling process, oil in a quenching process, crystal lattice in a solid state diffusion"@en)
+SubClassOf(:PMD_0020114 <http://purl.obolibrary.org/obo/BFO_0000023>)
 
 
 AnnotationAssertion(rdfs:label <https://orcid.org/0000-0001-6772-1943> "Martin Glauer")


### PR DESCRIPTION
Added `fluid  (object)` class and `medium role` to describe medium relevant for processes (see exapmles under `medium role`). Adjusted taxonomy under `object` class