### PR TITLE
changed continuant to independent continuant in the TQC axiom

### DIFF
--- a/src/ontology/components/pmdco-shared.owl
+++ b/src/ontology/components/pmdco-shared.owl
@@ -26,6 +26,8 @@ Declaration(Class(:PMD_0000946))
 Declaration(Class(:PMD_0000992))
 Declaration(Class(:PMD_0020113))
 Declaration(Class(:PMD_0020114))
+Declaration(Class(:PMD_0020209))
+Declaration(Class(:PMD_0020210))
 Declaration(Class(:PMD_0060005))
 Declaration(Class(:PMD_0060009))
 Declaration(ObjectProperty(obo:OBI_0000293))
@@ -228,7 +230,7 @@ AnnotationAssertion(obo:IAO_0000116 :PMD_0000068 "For any temporally qualified c
 AnnotationAssertion(rdfs:label :PMD_0000068 "temporally qualified continuant"@en)
 AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> :PMD_0000068 "A temporally qualified continuant is a continuant that, by reference to a determinate temporal region, is such as to possess its properties only for so long as that period obtains, being otherwise in its essentiality unchanged."@en)
 AnnotationAssertion(:PMD_0001032 :PMD_0000068 "https://github.com/materialdigital/core-ontology/issues/185")
-EquivalentClasses(:PMD_0000068 ObjectIntersectionOf(obo:BFO_0000002 ObjectSomeValuesFrom(obo:BFO_0000108 obo:BFO_0000008) ObjectSomeValuesFrom(:PMD_0000070 ObjectIntersectionOf(obo:BFO_0000002 ObjectComplementOf(:PMD_0000068)))))
+EquivalentClasses(:PMD_0000068 ObjectIntersectionOf(obo:BFO_0000004 ObjectSomeValuesFrom(obo:BFO_0000108 obo:BFO_0000008) ObjectSomeValuesFrom(:PMD_0000070 ObjectIntersectionOf(obo:BFO_0000004 ObjectComplementOf(:PMD_0000068)))))
 
 # Class: :PMD_0000501 (1D)
 
@@ -285,6 +287,16 @@ AnnotationAssertion(rdfs:label :PMD_0020114 "medium role"@en)
 AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> :PMD_0020114 "Medium role is a role beared by an object which implies that the object serves as an intermediary for the transmission of something else, like energy, force, or information."@en)
 AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#example> :PMD_0020114 "Air in the air cooling process, N2 atmosphere in a furnace cooling process, oil in a quenching process, crystal lattice in a solid state diffusion"@en)
 SubClassOf(:PMD_0020114 obo:BFO_0000023)
+
+# Class: :PMD_0020209 (operation)
+
+AnnotationAssertion(rdfs:label :PMD_0020209 "operation"@en)
+SubClassOf(:PMD_0020209 obo:BFO_0000015)
+
+# Class: :PMD_0020210 (alteration of quality)
+
+AnnotationAssertion(rdfs:label :PMD_0020210 "alteration of quality"@en)
+SubClassOf(:PMD_0020210 obo:BFO_0000015)
 
 # Class: :PMD_0060005 (categorical measurement datum)
 


### PR DESCRIPTION
Changing 'continuant' to 'independent continuant' in the TQC axiom: 

`
'independent continuant'
 and ('exists at' some 'temporal region')
 and ('is state of' some 
    ('independent continuant'
     and (not ('temporally qualified continuant'))))
`