### PR TITLE
Fixed most validation errors

### DIFF
--- a/patterns/material property (quality)/shape-data.ttl
+++ b/patterns/material property (quality)/shape-data.ttl
@@ -17,6 +17,7 @@
 # Classes
 @prefix entity: <http://purl.obolibrary.org/obo/BFO_0000001> . 
 @prefix independent_continuant: <http://purl.obolibrary.org/obo/BFO_0000004> .
+@prefix material_entity: <http://purl.obolibrary.org/obo/BFO_0000040> .
 @prefix object: <http://purl.obolibrary.org/obo/BFO_0000030> .
 @prefix temporally_qualified_continuant:  <https://w3id.org/pmd/co/PMD_0000068> .
 @prefix portion_of_iron: <https://w3id.org/pmd/co/PMD_0020026> . 
@@ -36,15 +37,15 @@
 @prefix gram_per_cubic_centimetre: <http://purl.obolibrary.org/obo/UO_0000084> .
 @prefix degree_celsius: <http://purl.obolibrary.org/obo/UO_0000027> .
 @prefix mass_percentage: <http://purl.obolibrary.org/obo/UO_0000163> .
-@prefix application_of_heat_flux: <https://w3id.org/pmd/co/PMD_0000520> .
-@prefix change_of_temperature: <https://w3id.org/pmd/co/PMD_0000549> .
-@prefix change_of_aggrate_state: <https://w3id.org/pmd/co/PMD_0000547> .
+@prefix melting_process: <https://w3id.org/pmd/co/PMD_0000053> .
+@prefix process: <http://purl.obolibrary.org/obo/BFO_0000015> .
 
 
 # Sublcass relations 
-object: rdfs:subClassOf independent_continuant: .
-material: rdfs:subClassOf independent_continuant: .
-portion_of_iron: rdfs:subClassOf independent_continuant: .
+object: rdfs:subClassOf material_entity: .
+material_entity: rdfs:subClassOf independent_continuant: .
+material: rdfs:subClassOf material_entity: .
+portion_of_iron: rdfs:subClassOf material_entity: .
 quality: rdfs:subClassOf specifically_dependent_continuant: .
 mass: rdfs:subClassOf quality: .
 density: rdfs:subClassOf quality: .
@@ -53,9 +54,11 @@ mass_proportion: rdfs:subClassOf relational_quality: .
 behavioral_material_property: rdfs:subClassOf specifically_dependent_continuant: .
 melting_point: rdfs:subClassOf behavioral_material_property: .
 specifically_dependent_continuant: rdfs:subClassOf entity: .
-# Object properties
+melting_process: rdfs:subClassOf process: .
 
+# Object properties
 @prefix exists_at: <http://purl.obolibrary.org/obo/BFO_0000108> . 
+@prefix is_state_of: <https://w3id.org/pmd/co/PMD_0000070> .
 @prefix quality_of: <http://purl.obolibrary.org/obo/RO_0000080> .
 @prefix characteristic_of: <http://purl.obolibrary.org/obo/RO_0000052> .
 @prefix relational_quality_of: <https://w3id.org/pmd/co/PMD_0025999> .
@@ -63,11 +66,10 @@ specifically_dependent_continuant: rdfs:subClassOf entity: .
 @prefix has_specified_numeric_value: <http://purl.obolibrary.org/obo/OBI_0001937> . 
 @prefix has_measurement_unit_label: <http://purl.obolibrary.org/obo/IAO_0000039> .
 @prefix specifies_value_of: <http://purl.obolibrary.org/obo/OBI_0001927> .
-@prefix is_state_of: <https://w3id.org/pmd/co/PMD_0000070> .
 @prefix has_realization: <http://purl.obolibrary.org/obo/BFO_0000054> .
-@prefix stimulated_by: <https://w3id.org/pmd/co/PMD_0001030> .
-@prefix responds_with: <https://w3id.org/pmd/co/PMD_0001029> .
-
+@prefix participates_in: <http://purl.obolibrary.org/obo/RO_0000056> .
+@prefix has_participant: <http://purl.obolibrary.org/obo/RO_0000057> .
+has_participant: owl:inverseOf participates_in: .
 
 ### Instances ###
 
@@ -85,13 +87,14 @@ ex:svs_15_g a owl:NamedIndividual ,
             has_measurement_unit_label: gram: ; 
             specifies_value_of: ex:mass_metal_sheet .
 
+ex:tcq_temporal_region a owl:NamedIndividual ,
+                        temporal_region: .
         
 ex:tqc_steel_material a owl:NamedIndividual ,
                           material: ,
-                          temporally_qualified_continuant:;
-                          exists_at: ex:some_temporal_region_1;
-                          is_state_of: ex:steel_material 
-                          .
+                          temporally_qualified_continuant: ; 
+                      exists_at: ex:tcq_temporal_region ; 
+                      is_state_of: ex:steel_material .
 
 ex:density_steel a owl:NamedIndividual , 
                       density: ;
@@ -107,7 +110,8 @@ ex:svs_7_5_g_per_cm a owl:NamedIndividual ,
 
 # Behavioral material property
 ex:steel_material a owl:NamedIndividual ,
-                          material: .
+                          material: ; 
+                  participates_in: ex:melting_process .
 
 ex:svs_1500_deg_c a owl:NamedIndividual ,
                     scalar_value_specification: ;
@@ -117,16 +121,12 @@ ex:svs_1500_deg_c a owl:NamedIndividual ,
 
 ex:melting_temperature_steel a owl:NamedIndividual ,
                                 melting_point: ; 
-                                characteristic_of: ex:steel_material ;
-                                stimulated_by: ex:applying_heat_1 ;
-                                responds_with: ex:change_of_temp_1 ;
-                                has_realization: ex:change_of_aggrate_state_1 
-                                .
+                            characteristic_of: ex:steel_material ;
+                            has_realization: ex:melting_process .
 
-# The processes
-ex:applying_heat_1 a application_of_heat_flux: .  
-ex:change_of_temp_1 a change_of_temperature: .
-ex:change_of_aggrate_state_1 a change_of_aggrate_state: .
+ex:melting_process a owl:NamedIndividual ,
+                      melting_process: .
+
 
 # Relational quality
 ex:some_iron a owl:NamedIndividual , 

--- a/patterns/material property (quality)/shape.ttl
+++ b/patterns/material property (quality)/shape.ttl
@@ -79,8 +79,28 @@ shape:behavioral_material_property
             sh:path  obo:RO_0000052 ;  # characteristic of
             sh:minCount 1 ;
             sh:maxCount 1 ; 
-            sh:class obo:BFO_0000004 ; # independent continuant
+            sh:class obo:BFO_0000040 ; # material entity
 			sh:message "Behavioral material property must be a characteristic of exactly one independent continuant." ;
+            sh:sparql 
+            [
+                sh:message " Behavioral material property must be a characterisitc of a material entity, which participates in a process, and the same process realizes this behavioral property. " ;
+                sh:select """
+                    PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+                    PREFIX rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                    PREFIX obo:   <http://purl.obolibrary.org/obo/> 
+                    SELECT $this
+                    WHERE {
+                        # Simple path material entity
+                        $this obo:RO_0000052 ?simpleMaterialEntity .
+                        
+                        # Complex path material entity (Sequence Path)
+                        $this obo:BFO_0000054/obo:RO_0000057 ?complexMaterialEntity .
+                        
+                        # The constraint fails if the two values are NOT EQUAL
+                        FILTER (?simpleMaterialEntity != ?complexMaterialEntity)
+                    }
+                """ ;
+            ] ;
         ] ;
 
     # concretizes value specification
@@ -102,6 +122,13 @@ shape:behavioral_material_property
 			sh:class obo:BFO_0000008 ; #temporal region
 			sh:message "Behavioral material property must exist at some temporal region. " ;
 		] ;
+
+    sh:property 
+        [
+            sh:path obo:BFO_0000054 ; # has realization
+            sh:class obo:BFO_0000015 ; # process
+            sh:message "Behavioral material property must have realization  in some process. " ;
+        ] ;
    
    #TODO which other triples can be written with SDCs?
    sh:closed true ;

--- a/src/ontology/components/pmdco-qualities.owl
+++ b/src/ontology/components/pmdco-qualities.owl
@@ -268,7 +268,7 @@ AnnotationAssertion(skos:definition pmdco:PMD_0000005 "A property is a material 
 We only deal with intensive (system-size independent) materrial properties. Extensive properties that depend on the testpiece/specimen/probe size should be found in the respective testing method modules."@en)
 AnnotationAssertion(pmdco:PMD_0000060 pmdco:PMD_0000005 "true"^^xsd:boolean)
 SubClassOf(pmdco:PMD_0000005 obo:BFO_0000017)
-SubClassOf(pmdco:PMD_0000005 ObjectIntersectionOf(ObjectSomeValuesFrom(obo:RO_0000052 ObjectIntersectionOf(obo:BFO_0000040 ObjectSomeValuesFrom(obo:RO_0000056 ObjectIntersectionOf(pmdco:PMD_0000915 ObjectSomeValuesFrom(obo:BFO_0000199 obo:BFO_0000008))) ObjectSomeValuesFrom(obo:RO_0000056 ObjectIntersectionOf(pmdco:PMD_0000950 ObjectSomeValuesFrom(obo:BFO_0000199 obo:BFO_0000008))))) ObjectSomeValuesFrom(pmdco:PMD_0001029 pmdco:PMD_0000915) ObjectSomeValuesFrom(pmdco:PMD_0001030 pmdco:PMD_0000950)))
+SubClassOf(pmdco:PMD_0000005 ObjectSomeValuesFrom(obo:RO_0000052 ObjectIntersectionOf(obo:BFO_0000040 ObjectSomeValuesFrom(obo:RO_0000056 obo:BFO_0000015))))
 
 # Class: pmdco:PMD_0000503 (ASTM grainsize)
 
@@ -690,11 +690,11 @@ AnnotationAssertion(rdfs:label pmdco:PMD_0000882 "phase boundary"@en)
 AnnotationAssertion(skos:definition pmdco:PMD_0000882 "A phase boundary is a morphological property denoting the interface between two distinct phases of a material, such as solid-liquid or liquid-gas boundaries."@en)
 AnnotationAssertion(pmdco:PMD_0000060 pmdco:PMD_0000882 "true"^^xsd:boolean)
 SubClassOf(pmdco:PMD_0000882 pmdco:PMD_0000864)
-SubClassOf(pmdco:PMD_0000882 ObjectSomeValuesFrom(obo:BFO_0000054 pmdco:PMD_0000547))
 SubClassOf(pmdco:PMD_0000882 ObjectSomeValuesFrom(pmdco:PMD_0001029 pmdco:PMD_0000549))
 SubClassOf(pmdco:PMD_0000882 ObjectSomeValuesFrom(pmdco:PMD_0001030 pmdco:PMD_0000520))
 SubClassOf(pmdco:PMD_0000882 ObjectSomeValuesFrom(pmdco:PMD_0001030 pmdco:PMD_0000522))
 SubClassOf(pmdco:PMD_0000882 ObjectSomeValuesFrom(pmdco:PMD_0001030 pmdco:PMD_0000523))
+SubClassOf(pmdco:PMD_0000882 ObjectSomeValuesFrom(ObjectInverseOf(obo:BFO_0000055) pmdco:PMD_0000547))
 
 # Class: pmdco:PMD_0000889 (pore growth)
 


### PR DESCRIPTION
- Adjusted data for the SDC shapes to be conform with autoshapes, 

- Simpified the axiom for the behavioral material property

Went from:

`
('characteristic of' some 
('material entity' and ('participates in' some 
('responding process' and ('occupies temporal region' some 'temporal region'))) and ('participates in' some 
('stimulating process' and ('occupies temporal region' some 'temporal region'))))) and ('responds with' some 'responding process') and ('stimulated by' some 'stimulating process')
`

To:

`
'characteristic of' some 
('material entity' and ('participates in' some process))
`
Plus added SPARQL restriction, that the behavioral material property has realization by the same process, in which its material entity participates: 
`
SELECT $this
WHERE {
    # Simple path material entity
    $this obo:RO_0000052 ?simpleMaterialEntity .
    
    # Complex path material entity (Sequence Path)
    $this obo:BFO_0000054/obo:RO_0000057 ?complexMaterialEntity .
    
    # The constraint fails if the two values are NOT EQUAL
    FILTER (?simpleMaterialEntity != ?complexMaterialEntity)
}
`

Justification for the change: 
The idea behind the [stimulating ](https://w3id.org/pmd/co/PMD_0000950) and [responding processes](https://w3id.org/pmd/co/PMD_0000915) is not cleared up, and no one would use these classes in their abox as we do not have clear examples.
