### PR TITLE
318 fill template for semiconductors

### DIFF
--- a/src/ontology/components/pmdco-materials.owl
+++ b/src/ontology/components/pmdco-materials.owl
@@ -313,6 +313,8 @@ Declaration(Class(<https://w3id.org/pmd/co/PMD_0050150>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0050151>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0050152>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0060007>))
+Declaration(Class(<https://w3id.org/pmd/co/PMD_0090000>))
+Declaration(Class(<https://w3id.org/pmd/co/PMD_0090001>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0200001>))
 Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/BFO_0000051>))
 Declaration(ObjectProperty(<https://w3id.org/pmd/co/PMD_0001026>))
@@ -2501,6 +2503,20 @@ AnnotationAssertion(rdfs:label <https://w3id.org/pmd/co/PMD_0060007> "material s
 AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> <https://w3id.org/pmd/co/PMD_0060007> "A directive information entity that defines the composition, properties, performance criteria, and acceptable standards for a material, guiding its selection, processing, and application in a specific context."@en)
 AnnotationAssertion(<https://w3id.org/pmd/co/PMD_0000060> <https://w3id.org/pmd/co/PMD_0060007> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/pmd/co/PMD_0060007> <http://purl.obolibrary.org/obo/IAO_0000033>)
+
+# Class: <https://w3id.org/pmd/co/PMD_0090000> (semiconductor)
+
+AnnotationAssertion(rdfs:label <https://w3id.org/pmd/co/PMD_0090000> "semiconductor"@en)
+AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> <https://w3id.org/pmd/co/PMD_0090000> "A semiconductor is an engineered material representing a class of materials characterized by an electrical conductivity between that of a conductor and an insulator. This is a result of a range of inexistent energy states in ther electronic configuration between the valence and conduction band (bandgap)."@en)
+AnnotationAssertion(<https://w3id.org/pmd/co/PMD_0000060> <https://w3id.org/pmd/co/PMD_0090000> "true"^^xsd:boolean)
+SubClassOf(<https://w3id.org/pmd/co/PMD_0090000> <https://w3id.org/pmd/co/PMD_0000002>)
+
+# Class: <https://w3id.org/pmd/co/PMD_0090001> (semiconductivity)
+
+AnnotationAssertion(rdfs:label <https://w3id.org/pmd/co/PMD_0090001> "semiconductivity"@en)
+AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> <https://w3id.org/pmd/co/PMD_0090001> "Semiconductivity is the disposition of a material to conduct electricity only when a certain level of excitation elevates electron from the valence band into the conduction band."@en)
+AnnotationAssertion(<https://w3id.org/pmd/co/PMD_0000060> <https://w3id.org/pmd/co/PMD_0090001> "true"^^xsd:boolean)
+SubClassOf(<https://w3id.org/pmd/co/PMD_0090001> <http://purl.obolibrary.org/obo/BFO_0000016>)
 
 # Class: <https://w3id.org/pmd/co/PMD_0200001> (biodegradability)
 

--- a/src/ontology/components/pmdco-materials.owl
+++ b/src/ontology/components/pmdco-materials.owl
@@ -2514,7 +2514,7 @@ SubClassOf(<https://w3id.org/pmd/co/PMD_0090000> <https://w3id.org/pmd/co/PMD_00
 # Class: <https://w3id.org/pmd/co/PMD_0090001> (semiconductivity)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/pmd/co/PMD_0090001> "semiconductivity"@en)
-AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> <https://w3id.org/pmd/co/PMD_0090001> "Semiconductivity is the disposition of a material to conduct electricity only when a certain level of excitation elevates electron from the valence band into the conduction band."@en)
+AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> <https://w3id.org/pmd/co/PMD_0090001> "Semiconductivity is the disposition of a material to conduct electricity only when a certain level of excitation (via temperature, impurities, photonic excitation, electric field) elevates electrons from the valence band into the conduction band."@en)
 AnnotationAssertion(<https://w3id.org/pmd/co/PMD_0000060> <https://w3id.org/pmd/co/PMD_0090001> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/pmd/co/PMD_0090001> <http://purl.obolibrary.org/obo/BFO_0000016>)
 

--- a/src/ontology/components/pmdco-materials.owl
+++ b/src/ontology/components/pmdco-materials.owl
@@ -24,6 +24,7 @@ Declaration(Class(<https://w3id.org/pmd/co/PMD_0000512>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0000546>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0000577>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0000591>))
+Declaration(Class(<https://w3id.org/pmd/co/PMD_0000619>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0000639>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0000654>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0000661>))
@@ -315,6 +316,7 @@ Declaration(Class(<https://w3id.org/pmd/co/PMD_0050152>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0060007>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0090000>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0090001>))
+Declaration(Class(<https://w3id.org/pmd/co/PMD_0090002>))
 Declaration(Class(<https://w3id.org/pmd/co/PMD_0200001>))
 Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/BFO_0000051>))
 Declaration(ObjectProperty(<https://w3id.org/pmd/co/PMD_0001026>))
@@ -2511,6 +2513,7 @@ AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> <https://w3
 AnnotationAssertion(<https://w3id.org/pmd/co/PMD_0000060> <https://w3id.org/pmd/co/PMD_0090000> "true"^^xsd:boolean)
 EquivalentClasses(<https://w3id.org/pmd/co/PMD_0090000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000091> <https://w3id.org/pmd/co/PMD_0090001>))
 SubClassOf(<https://w3id.org/pmd/co/PMD_0090000> <https://w3id.org/pmd/co/PMD_0000002>)
+SubClassOf(<https://w3id.org/pmd/co/PMD_0090000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000086> <https://w3id.org/pmd/co/PMD_0090002>))
 
 # Class: <https://w3id.org/pmd/co/PMD_0090001> (semiconductivity)
 
@@ -2518,6 +2521,14 @@ AnnotationAssertion(rdfs:label <https://w3id.org/pmd/co/PMD_0090001> "semiconduc
 AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> <https://w3id.org/pmd/co/PMD_0090001> "Semiconductivity is the disposition of a material to conduct electricity only when a certain level of excitation (via temperature, impurities, photonic excitation, electric field) elevates electrons from the valence band into the conduction band."@en)
 AnnotationAssertion(<https://w3id.org/pmd/co/PMD_0000060> <https://w3id.org/pmd/co/PMD_0090001> "true"^^xsd:boolean)
 SubClassOf(<https://w3id.org/pmd/co/PMD_0090001> <http://purl.obolibrary.org/obo/BFO_0000016>)
+
+# Class: <https://w3id.org/pmd/co/PMD_0090002> (band gap)
+
+AnnotationAssertion(rdfs:label <https://w3id.org/pmd/co/PMD_0090002> "band gap"@en)
+AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#altLabel> <https://w3id.org/pmd/co/PMD_0090002> "bandgap"@en)
+AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#altLabel> <https://w3id.org/pmd/co/PMD_0090002> "energy gap"@en)
+AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> <https://w3id.org/pmd/co/PMD_0090002> "A bandgap is an energy range in a solid where no electronic states exist.")
+SubClassOf(<https://w3id.org/pmd/co/PMD_0090002> <https://w3id.org/pmd/co/PMD_0000619>)
 
 # Class: <https://w3id.org/pmd/co/PMD_0200001> (biodegradability)
 

--- a/src/ontology/components/pmdco-materials.owl
+++ b/src/ontology/components/pmdco-materials.owl
@@ -2507,8 +2507,9 @@ SubClassOf(<https://w3id.org/pmd/co/PMD_0060007> <http://purl.obolibrary.org/obo
 # Class: <https://w3id.org/pmd/co/PMD_0090000> (semiconductor)
 
 AnnotationAssertion(rdfs:label <https://w3id.org/pmd/co/PMD_0090000> "semiconductor"@en)
-AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> <https://w3id.org/pmd/co/PMD_0090000> "A semiconductor is an engineered material representing a class of materials characterized by an electrical conductivity between that of a conductor and an insulator. This is a result of a range of inexistent energy states in ther electronic configuration between the valence and conduction band (bandgap)."@en)
+AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> <https://w3id.org/pmd/co/PMD_0090000> "A semiconductor is an engineered material representing a class of materials characterized by an electrical conductivity between that of a conductor and an insulator. This is a result of a range of inexistent energy states in ther electron configuration between the valence and conduction band (bandgap)."@en)
 AnnotationAssertion(<https://w3id.org/pmd/co/PMD_0000060> <https://w3id.org/pmd/co/PMD_0090000> "true"^^xsd:boolean)
+EquivalentClasses(<https://w3id.org/pmd/co/PMD_0090000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000091> <https://w3id.org/pmd/co/PMD_0090001>))
 SubClassOf(<https://w3id.org/pmd/co/PMD_0090000> <https://w3id.org/pmd/co/PMD_0000002>)
 
 # Class: <https://w3id.org/pmd/co/PMD_0090001> (semiconductivity)

--- a/src/ontology/pmdco-idranges.owl
+++ b/src/ontology/pmdco-idranges.owl
@@ -108,7 +108,6 @@ Annotations:
         xsd:integer[>= 70000 , <= 79999]
 
 
-
 Datatype: idrange:10
 
 Annotations: 
@@ -116,6 +115,15 @@ Annotations:
     
     EquivalentTo: 
         xsd:integer[>= 25001 , <= 25999]
+
+
+Datatype: idrange:11
+
+Annotations: 
+        allocatedto: "thnlrd"
+    
+    EquivalentTo: 
+        xsd:integer[>= 90000 , <= 94999]
 
 
 Datatype: idrange:999


### PR DESCRIPTION
I added the bare minimum of semiconductivity in the materials module, i.e. _semiconductor, semiconductivity_ and _band gap_ , as well as accompanying axioms.

Additional subclasses of semiconductors will be added to the shared spreadsheet later on.