### PR TITLE
2 taxonomy fixes related to "unit cell" and "stiffness"

### DIFF
--- a/src/ontology/components/pmdco-materials.owl
+++ b/src/ontology/components/pmdco-materials.owl
@@ -1187,11 +1187,12 @@ AnnotationAssertion(rdfs:label <https://w3id.org/pmd/co/PMD_0020199> "slip plane
 AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> <https://w3id.org/pmd/co/PMD_0020199> "A slip plane is a fiat surface that corresponds to a crystallographic plane of a 3D crystal along which dislocations can glide"@en)
 SubClassOf(<https://w3id.org/pmd/co/PMD_0020199> <http://purl.obolibrary.org/obo/BFO_0000146>)
 
-# Class: <https://w3id.org/pmd/co/PMD_0020206> (unit cell (3D crystal))
+# Class: <https://w3id.org/pmd/co/PMD_0020206> (unit cell)
 
-AnnotationAssertion(rdfs:label <https://w3id.org/pmd/co/PMD_0020206> "unit cell (3D crystal)"@en)
-AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> <https://w3id.org/pmd/co/PMD_0020206> "A unit cell (3D crystal) is a three-dimensional spatial region that represents the smallest repeating region whose spatial translation reproduces a crystal lattice."@en)
-SubClassOf(<https://w3id.org/pmd/co/PMD_0020206> <http://purl.obolibrary.org/obo/BFO_0000028>)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <https://w3id.org/pmd/co/PMD_0020206> "https://www.physics-in-a-nutshell.com/article/5/unit-cell-primitive-cell-and-wigner-seitz-cell")
+AnnotationAssertion(rdfs:label <https://w3id.org/pmd/co/PMD_0020206> "unit cell"@en)
+AnnotationAssertion(<http://www.w3.org/2004/02/skos/core#definition> <https://w3id.org/pmd/co/PMD_0020206> "Unit cell is a immaterial entity that represents the a smallest volume element a repetitive arrangement of which can build  up the whole crystal lattice without overplaps or gaps, and there is no further partition of the unit cell that could itself be used as a unit cell."@en)
+SubClassOf(<https://w3id.org/pmd/co/PMD_0020206> <http://purl.obolibrary.org/obo/BFO_0000141>)
 
 # Class: <https://w3id.org/pmd/co/PMD_0020208> (slip direction)
 

--- a/src/ontology/components/pmdco-qualities.owl
+++ b/src/ontology/components/pmdco-qualities.owl
@@ -759,7 +759,7 @@ SubClassOf(pmdco:PMD_0000947 pmdco:PMD_0000506)
 AnnotationAssertion(rdfs:label pmdco:PMD_0000949 "stiffness"@en)
 AnnotationAssertion(skos:definition pmdco:PMD_0000949 "The stiffness is a material property describing the resistance of a material to deformation under an applied force."@en)
 AnnotationAssertion(pmdco:PMD_0000060 pmdco:PMD_0000949 "true"^^xsd:boolean)
-SubClassOf(pmdco:PMD_0000949 pmdco:PMD_0000005)
+SubClassOf(pmdco:PMD_0000949 pmdco:PMD_0000848)
 SubClassOf(pmdco:PMD_0000949 ObjectSomeValuesFrom(pmdco:PMD_0001029 pmdco:PMD_0000596))
 DisjointClasses(pmdco:PMD_0000949 pmdco:PMD_0000952)
 


### PR DESCRIPTION
Moved unit cell under immaterial entities (discussed with Philipp)
Moved stiffness under mechanical property instead of material property