### PR TITLE
Comment out public/docs directory creation

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -78,7 +78,7 @@ jobs:
            ls v3.0.0
            ls v3.0.0/docs/docs_HTML/HTML_Docs/
     
-           mkdir public/docs
+           #mkdir public/docs
            mkdir public/3.0.0/docs
            #cp -r v3.0.0/docs/docs_HTML/HTML_Docs/* public/docs/
            cp -r v3.0.0/docs/docs_HTML/HTML_Docs/* public/3.0.0/docs/


### PR DESCRIPTION
Comment out the creation of public/docs directory and the copy command for HTML docs.