### PR TITLE
removed property chain from relational quality of, addedtowards

### DIFF
--- a/src/ontology/components/pmdco-axioms-shared.owl
+++ b/src/ontology/components/pmdco-axioms-shared.owl
@@ -122,7 +122,7 @@ SubClassOf(:PMD_0000816 ObjectSomeValuesFrom(obo:RO_0009006 :PMD_0000591))
 
 SubClassOf(:PMD_0000829 ObjectSomeValuesFrom(obo:RO_0009006 :PMD_0020312))
 
-# Class: :PMD_0000849 (mechanical property analyzing process)
+# Class: :PMD_0000849 (Mechanische Eigenschaften Analyseverfahren)
 
 SubClassOf(:PMD_0000849 ObjectSomeValuesFrom(obo:RO_0009006 :PMD_0020311))
 
@@ -156,7 +156,7 @@ SubClassOf(:PMD_0001017 ObjectSomeValuesFrom(obo:RO_0009006 :PMD_0000551))
 
 SubClassOf(:PMD_0001018 ObjectSomeValuesFrom(obo:RO_0009006 :PMD_0000551))
 
-# Class: :PMD_0020022 (corrosion)
+# Class: :PMD_0020022 (Korrosion)
 
 SubClassOf(:PMD_0020022 ObjectSomeValuesFrom(:PMD_0025013 ObjectIntersectionOf(:PMD_0000551 ObjectSomeValuesFrom(obo:RO_0000080 ObjectIntersectionOf(obo:BFO_0000040 ObjectSomeValuesFrom(obo:RO_0000091 obo:BFO_0000016))))))
 
@@ -172,7 +172,6 @@ SubClassOf(:PMD_0025997 ObjectSomeValuesFrom(obo:OBI_0001927 ObjectIntersectionO
 SubClassOf(:PMD_0025997 ObjectAllValuesFrom(obo:RO_0002350 :PMD_0020004))
 
 
-SubObjectPropertyOf(ObjectPropertyChain(:PMD_0025999 obo:BFO_0000050) :PMD_0025999)
 AnnotationAssertion(obo:IAO_0000114 :PMD_0025019 obo:IAO_0000122)
 AnnotationAssertion(obo:IAO_0000116 :PMD_0025019 "Ideally, a temporally qualified continuant must be used as a participant in a process where the qualities of the participant changes.This temporally qualitified continuant has an instance of quality with one on value before the process and another instance of the same quality with another on value after the process."@en)
 AnnotationAssertion(obo:IAO_0000116 :PMD_0025019 "In the axiom, the instance of quality in \"refers to\" triple must be the same instance as in \"has quality\" triple."@en)

--- a/src/ontology/components/pmdco-qualities.owl
+++ b/src/ontology/components/pmdco-qualities.owl
@@ -636,7 +636,7 @@ AnnotationAssertion(skos:definition pmdco:PMD_0025999 "eine Beziehung zwischen e
 AnnotationAssertion(skos:example pmdco:PMD_0025999 "mass proportion m is relational qualitiy of material, and the same mass proportion m is relational qualitiy of portion of iron"@en)
 
 
-DisjointClasses(pmdco:PMD_0000553 pmdco:PMD_0000619 pmdco:PMD_0020132 pmdco:PMD_0020133 pmdco:PMD_0020142 pmdco:PMD_0020161)
+
 
 ############################
 #   Classes
@@ -761,7 +761,7 @@ AnnotationAssertion(skos:definition pmdco:PMD_0000503 "Die ASTM-Korngröße ist 
 AnnotationAssertion(skos:definition pmdco:PMD_0000503 "The ASTM grain size is a quality that is measured through a process that follows the ASTM standard."@en)
 AnnotationAssertion(pmdco:PMD_0000060 pmdco:PMD_0000503 "true"^^xsd:boolean)
 
-# Class: pmdco:PMD_0000505 (acoustic absorption coefficient)
+# Class: pmdco:PMD_0000505 (Schallabsorptionskoeffizient)
 
 AnnotationAssertion(obo:IAO_0000117 pmdco:PMD_0000505 "PERSON: Joerg Waitelonis")
 AnnotationAssertion(rdfs:label pmdco:PMD_0000505 "Schallabsorptionskoeffizient"@de)
@@ -1492,7 +1492,7 @@ AnnotationAssertion(skos:definition pmdco:PMD_0000961 "The sublimation point is 
 AnnotationAssertion(pmdco:PMD_0000060 pmdco:PMD_0000961 "true"^^xsd:boolean)
 SubClassOf(pmdco:PMD_0000961 pmdco:PMD_0020164)
 
-# Class: pmdco:PMD_0000965 (surface layer (fiat object part))
+# Class: pmdco:PMD_0000965 (Oberflächenschicht (Fiat-Objektteil))
 
 AnnotationAssertion(obo:IAO_0000114 pmdco:PMD_0000965 obo:IAO_0000122)
 AnnotationAssertion(obo:IAO_0000117 pmdco:PMD_0000965 "PERSON: Joerg Waitelonis")
@@ -1570,7 +1570,7 @@ AnnotationAssertion(pmdco:PMD_0000060 pmdco:PMD_0000981 "true"^^xsd:boolean)
 SubClassOf(pmdco:PMD_0000981 pmdco:PMD_0020353)
 SubClassOf(pmdco:PMD_0000981 ObjectSomeValuesFrom(obo:BFO_0000054 pmdco:PMD_0000520))
 
-# Class: pmdco:PMD_0000996 (triple point)
+# Class: pmdco:PMD_0000996 (Tripelpunkt)
 
 AnnotationAssertion(obo:IAO_0000114 pmdco:PMD_0000996 obo:IAO_0000122)
 AnnotationAssertion(obo:IAO_0000117 pmdco:PMD_0000996 "PERSON: Joerg Waitelonis")
@@ -1725,7 +1725,7 @@ AnnotationAssertion(rdfs:label pmdco:PMD_0020005 "porosity"@en)
 AnnotationAssertion(skos:definition pmdco:PMD_0020005 "itensive quality embodiying the fraction of the materials (enclosing) spatial region occupied by pores."@en)
 SubClassOf(pmdco:PMD_0020005 pmdco:PMD_0020335)
 
-# Class: pmdco:PMD_0020022 (corrosion)
+# Class: pmdco:PMD_0020022 (Korrosion)
 
 AnnotationAssertion(obo:IAO_0000114 pmdco:PMD_0020022 obo:IAO_0000122)
 AnnotationAssertion(obo:IAO_0000117 pmdco:PMD_0020022 "PERSON: Philipp von Hartrott")
@@ -1929,7 +1929,7 @@ AnnotationAssertion(pmdco:PMD_0000060 pmdco:PMD_0020133 "true"^^xsd:boolean)
 SubClassOf(pmdco:PMD_0020133 pmdco:PMD_0023000)
 SubClassOf(pmdco:PMD_0020133 ObjectSomeValuesFrom(obo:RO_0000080 ObjectUnionOf(obo:BFO_0000024 obo:BFO_0000027 obo:BFO_0000030)))
 
-# Class: pmdco:PMD_0020134 (DEPRECATED stimulus role)
+# Class: pmdco:PMD_0020134 (DEPRECATED Reizrolle)
 
 AnnotationAssertion(rdfs:comment pmdco:PMD_0020134 "Will deal with causality later")
 AnnotationAssertion(rdfs:label pmdco:PMD_0020134 "DEPRECATED Reizrolle"@de)
@@ -5249,7 +5249,7 @@ AnnotationAssertion(skos:example pmdco:PMD_0080186 "Polished aluminum foil has h
 AnnotationAssertion(pmdco:PMD_0000060 pmdco:PMD_0080186 "true"^^xsd:boolean)
 SubClassOf(pmdco:PMD_0080186 pmdco:PMD_0000877)
 
-# Class: pmdco:PMD_0080187 (Strahlungsabsorptionsfähigkeit)
+# Class: pmdco:PMD_0080187 (radiation absorption capability)
 
 AnnotationAssertion(obo:IAO_0000114 pmdco:PMD_0080187 obo:IAO_0000122)
 AnnotationAssertion(obo:IAO_0000116 pmdco:PMD_0080187 "Necessary and sufficient conditions for 'radiation absorption capability' have not yet been formalized. The term is defined as a specific subtype of 'optical capability'. Distinguishing criteria are domain-specific and depend on measurement conventions or source terminology not yet expressed as OWL restrictions."@en)
@@ -5385,7 +5385,7 @@ AnnotationAssertion(skos:example pmdco:PMD_0080198 "Aluminum has a linear therma
 AnnotationAssertion(pmdco:PMD_0000060 pmdco:PMD_0080198 "true"^^xsd:boolean)
 SubClassOf(pmdco:PMD_0080198 pmdco:PMD_0080196)
 
-# Class: pmdco:PMD_0080200 (flame resistance)
+# Class: pmdco:PMD_0080200 (Flammbeständigkeit)
 
 AnnotationAssertion(obo:IAO_0000114 pmdco:PMD_0080200 obo:IAO_0000122)
 AnnotationAssertion(obo:IAO_0000116 pmdco:PMD_0080200 "Necessary and sufficient conditions for 'flame resistance' have not yet been formalized. The term is defined as a specific subtype of 'thermal capability', disjoint from 'flammability' as the inverse capability. Distinguishing criteria are domain-specific and depend on measurement conventions not yet expressed as OWL restrictions."@en)
@@ -5505,7 +5505,7 @@ AnnotationAssertion(skos:definition pmdco:PMD_0020007 "Monoklines Bravais-Gitter
 AnnotationAssertion(skos:definition pmdco:PMD_0020007 "monoclinic Bravais lattice with primitive centering (mP), having one 2-fold rotation axis with one oblique angle and two right angles between unit cell axes"@en)
 AnnotationAssertion(pmdco:PMD_0000060 pmdco:PMD_0020007 "true"^^xsd:boolean)
 
-# Individual: pmdco:PMD_0020008 (Bravais-Gitter monoklin basiszentriert)
+# Individual: pmdco:PMD_0020008 (OBSOLETE bravais lattice monoclinic base-centered)
 
 AnnotationAssertion(rdfs:label pmdco:PMD_0020008 "Bravais-Gitter monoklin basiszentriert"@de)
 AnnotationAssertion(rdfs:label pmdco:PMD_0020008 "OBSOLETE bravais lattice monoclinic base-centered"@en)
@@ -5811,6 +5811,7 @@ DataPropertyAssertion(obo:OBI_0001937 pmdco:PMD_0020368 "60221408600000000000000
 
 
 DisjointClasses(pmdco:PMD_0000535 pmdco:PMD_0000851 pmdco:PMD_0000961 pmdco:PMD_0000996)
+DisjointClasses(pmdco:PMD_0000553 pmdco:PMD_0000619 pmdco:PMD_0020132 pmdco:PMD_0020133 pmdco:PMD_0020142 pmdco:PMD_0020161)
 DisjointClasses(pmdco:PMD_0000587 pmdco:PMD_0000889 pmdco:PMD_0000953)
 DisjointClasses(pmdco:PMD_0020102 pmdco:PMD_0020103 pmdco:PMD_0020104)
 DisjointClasses(pmdco:PMD_0020164 pmdco:PMD_0020167 pmdco:PMD_0020168 pmdco:PMD_0020169)
@@ -5820,5 +5821,4 @@ DisjointClasses(pmdco:PMD_0020307 pmdco:PMD_0020308 pmdco:PMD_0020309)
 DisjointClasses(pmdco:PMD_0020364 pmdco:PMD_0020365 pmdco:PMD_0020366)
 DisjointClasses(pmdco:PMD_0020371 pmdco:PMD_0020372 pmdco:PMD_0020373)
 DifferentIndividuals(pmdco:PMD_0020006 pmdco:PMD_0020007 pmdco:PMD_0020008 pmdco:PMD_0020009 pmdco:PMD_0020010 pmdco:PMD_0020011 pmdco:PMD_0020012 pmdco:PMD_0020013 pmdco:PMD_0020014 pmdco:PMD_0020015 pmdco:PMD_0020016 pmdco:PMD_0020017 pmdco:PMD_0020018 pmdco:PMD_0020019)
-SubObjectPropertyOf(ObjectPropertyChain(obo:BFO_0000051 pmdco:PMD_0025998) pmdco:PMD_0025998)
 )

--- a/src/ontology/imports/ro_terms.txt
+++ b/src/ontology/imports/ro_terms.txt
@@ -35,6 +35,7 @@ http://purl.obolibrary.org/obo/RO_0002020 # transports
 http://purl.obolibrary.org/obo/RO_0002328 # funcionally related to
 http://purl.obolibrary.org/obo/RO_0002002 # has 2D boundary
 http://purl.obolibrary.org/obo/RO_0002000 # 2D boundary of
+http://purl.obolibrary.org/obo/RO_0002503 # towards
 
 # we need these imports for the inclusion of domains and ranges
 # (SUBSET method does not do that automatically)


### PR DESCRIPTION
The property chain on "relational quality of" with "part of" was a questionable idea due to the transitivity of the latter. Removed its for the sake of reasoning 